### PR TITLE
controller - implement tmp file cleanup

### DIFF
--- a/main.py
+++ b/main.py
@@ -169,6 +169,7 @@ def main():
     app.installEventFilter(window)
     app.exec_()
     atexit.register(controller.write_config)
+    atexit.register(controller.cleanup_tmp_files)
 
 
 

--- a/parameters.py
+++ b/parameters.py
@@ -342,6 +342,9 @@ class AppParameters(object):
         #print(self.config_path)
 
 
+        if self.controller:
+            self.controller.set_tmp_place(self.tmp_place)
+
         self.config.read(self.config_path)
 
         self.first_run()
@@ -437,11 +440,11 @@ class AppParameters(object):
             return False
         else:
 
-            with open(self.tmp_place+self.printers_filename, 'wb') as out_file:
+            with open(self.controller.get_tmp_file(self.printers_filename), 'wb') as out_file:
                 #shutil.copyfileobj(r, out_file)
                 out_file.write(r.data)
 
-            with open(self.tmp_place+self.printers_filename, 'r') as in_file:
+            with open(self.controller.get_tmp_file(self.printers_filename), 'r') as in_file:
                 printers_data = json.load(in_file)
                 materials_files_list = [printers_data['printers'][i]['material_parameters_file'] for i in
                                     printers_data['printers'] if i not in ['default']]
@@ -452,13 +455,13 @@ class AppParameters(object):
 
             for i in materials_files_list:
                 r_mat = self.http.request('GET', self.json_settings_url + i)
-                with open(self.tmp_place+i, 'wb') as out_file:
+                with open(self.controller.get_tmp_file(i), 'wb') as out_file:
                     out_file.write(r_mat.data)
         return True
 
     def check_versions(self):
         old = self.user_folder + self.printers_filename
-        new = self.tmp_place + self.printers_filename
+        new = self.controller.get_tmp_file(self.printers_filename)
         #print(old)
         #print(new)
         #out = self.get_actual_version(old, new)
@@ -480,14 +483,14 @@ class AppParameters(object):
             copyfile(new, self.user_folder + self.printers_filename)
 
         for i in new_material_list:
-            new_material_version = self.get_materials_info(self.tmp_place + i)
+            new_material_version = self.get_materials_info(self.controller.get_tmp_file(i))
             old_material_version = self.get_materials_info(self.user_folder + i)
             if new_material_version:
                 if old_material_version:
                     if new_material_version > old_material_version:
-                        copyfile(self.tmp_place + i, self.user_folder + i)
+                        copyfile(self.controller.get_tmp_file(i), self.user_folder + i)
                 else:
-                    copyfile(self.tmp_place + i, self.user_folder + i)
+                    copyfile(self.controller.get_tmp_file(i), self.user_folder + i)
             else:
                 self.use_default_files()
 

--- a/slicer.py
+++ b/slicer.py
@@ -109,7 +109,7 @@ class Slic3rEngineRunner(QObject):
         self.is_running = True
         self.controller = controller
 
-        self.gcode = GCode(self.controller.app_config.tmp_place + 'out.gcode', self.controller, None, None)
+        self.gcode = GCode(self.controller.get_tmp_file('out.gcode'), self.controller, None, None)
 
         system_platform = platform.system()
         if system_platform in ['Linux']:
@@ -241,23 +241,23 @@ class Slic3rEngineRunner(QObject):
 
 
     def slice(self):
-        self.save_configuration(self.controller.app_config.tmp_place + 'prusacontrol.ini')
+        self.save_configuration(self.controller.get_tmp_file('prusacontrol.ini'))
         self.process = subprocess.Popen(
-                    self.slicer_place + [self.controller.app_config.tmp_place + 'tmp.prusa', '--load',
-                                         self.controller.app_config.tmp_place + 'prusacontrol.ini', '--output',
-                                         self.controller.app_config.tmp_place + 'out.gcode', '--dont-arrange'],
+                    self.slicer_place + [self.controller.get_tmp_file('tmp.prusa'), '--load',
+                                         self.controller.get_tmp_file('prusacontrol.ini'), '--output',
+                                         self.controller.get_tmp_file('out.gcode'), '--dont-arrange'],
                     stdout=subprocess.PIPE)
 
         #if self.controller.is_multimaterial() and not self.controller.is_single_material_mode():
         #    self.process = subprocess.Popen(
-        #        self.slicer_place + [self.controller.app_config.tmp_place + 'tmp.prusa', '--load',
-        #                             self.controller.app_config.tmp_place + 'prusacontrol.ini', '--output',
-        #                             self.controller.app_config.tmp_place + 'out.gcode', '--dont-arrange'],
+        #        self.slicer_place + [self.controller.get_tmp_file('tmp.prusa'), '--load',
+        #                             self.controller.get_tmp_file('prusacontrol.ini'), '--output',
+        #                             self.controller.get_tmp_file('out.gcode'), '--dont-arrange'],
         #        stdout=subprocess.PIPE)
         #else:
-        #    self.process = subprocess.Popen(self.slicer_place + [self.controller.app_config.tmp_place + 'tmp.stl', '--load',
-        #                            self.controller.app_config.tmp_place + 'prusacontrol.ini', '--output',
-        #                            self.controller.app_config.tmp_place + 'out.gcode', '--dont-arrange'],
+        #    self.process = subprocess.Popen(self.slicer_place + [self.controller.get_tmp_file('tmp.stl'), '--load',
+        #                            self.controller.get_tmp_file('prusacontrol.ini'), '--output',
+        #                            self.controller.get_tmp_file('out.gcode'), '--dont-arrange'],
         #                           stdout=subprocess.PIPE)
         self.check_progress()
 


### PR DESCRIPTION
This implements tmp file cleanup.  It's not a good idea to leave tmp files behind after exit as they can be quite large.  A lot of Linux configurations set up /tmp in ram, so you end up wasting a lot of ram, potentially causing problems.

It may be a good idea to move the initialization of tmp_place which is currently in AppParameters to Controller although I haven't done this in this pull request.
